### PR TITLE
Set default font size to 24 half points (per spec)

### DIFF
--- a/rtf.js
+++ b/rtf.js
@@ -466,7 +466,7 @@ RTFJS.Document.prototype.parse = function(blob) {
 			this.strikethrough = false;
 			this.dblstrikethrough = false;
 			this.colorindex = 0;
-			this.fontsize = 12;
+			this.fontsize = 24;
 		}
 	};
 	


### PR DESCRIPTION
Since this property contains a value in half points when set using the parser, the default value also needs to be in half points.