### PR TITLE
Use current charset instead of global codepage

### DIFF
--- a/rtf.js
+++ b/rtf.js
@@ -621,7 +621,7 @@ RTFJS.Document.prototype.parse = function(blob, renderer) {
 		readChar: function() {
 			if (this.pos < this.data.length) {
 				parser.column++;
-				return cptable[this.codepage].dec[this.data[this.pos++]];
+				return String.fromCharCode(this.data[this.pos++]);
 			}
 			
 			throw new RTFJS.Error("Unexpected end of file");

--- a/rtf.js
+++ b/rtf.js
@@ -160,7 +160,7 @@ if (typeof RTFJS === "undefined") {
 		},
 		
 		_charsetMap: {
-			"0": "windows-1252",
+			"0": 1252,
 			// TODO
 		},
 		_mapCharset: function(idx) {
@@ -1931,8 +1931,17 @@ RTFJS.Document.prototype.parse = function(blob, renderer) {
 				if (isNaN(param))
 					throw new RTFJS.Error("Could not parse hexadecimal number");
 				
-				if (process != null)
-					appendText(cptable[parser.codepage].dec[param]);
+				if (process != null) {
+					// Looking for current fonttbl charset
+					var codepage = parser.codepage;
+					if (parser.state.chp.hasOwnProperty("fontfamily")) {
+						idx = parser.state.chp.fontfamily;
+						if (inst._fonts != undefined && inst._fonts[idx] != null)
+							codepage = inst._fonts[idx].charset;
+					}
+					
+					appendText(cptable[codepage].dec[param]);
+				}
 			} else if (process != null) {
 				var text = process(ch, param);
 				if (text != null)

--- a/rtf.js
+++ b/rtf.js
@@ -160,8 +160,36 @@ if (typeof RTFJS === "undefined") {
 		},
 		
 		_charsetMap: {
-			"0": 1252,
-			// TODO
+			"0":   1252, // ANSI_CHARSET
+			"2":   42,    // Symbol
+			"77":  10000, // Mac Roman
+			"78":  10001, // Mac Shift Jis
+			"79":  10003, // Mac Hangul
+			"80":  10008, // Mac GB2312
+			"81":  10002, // Mac Big5
+			"83":  10005, // Mac Hebrew
+			"84":  10004, // Mac Arabic
+			"85":  10006, // Mac Greek
+			"86":  10081, // Mac Turkish
+			"87":  10021, // Mac Thai
+			"88":  10029, // Mac East Europe
+			"89":  10007, // Mac Russian
+			"128": 932,  // SHIFTJIS_CHARSET
+			"129": 949,  // HANGEUL_CHARSET
+			"130": 1361, // JOHAB_CHARSET
+			"134": 936,  // GB2313_CHARSET
+			"136": 950,  // CHINESEBIG5_CHARSET
+			"161": 1253, // GREEK_CHARSET
+			"162": 1254, // TURKISH_CHARSET
+			"163": 1258, // VIETNAMESE_CHARSET
+			"177": 1255, // HEBREW_CHARSET
+			"178": 1256, // ARABIC_CHARSET
+			"186": 1257, // BALTIC_CHARSET
+			"204": 1251, // RUSSIAN_CHARSET
+			"222": 874,  // THAI_CHARSET
+			"238": 1250, // EE_CHARSET (Eastern European)
+			"254": 437,  // PC 437
+			"255": 850,  // OEM
 		},
 		_mapCharset: function(idx) {
 			return this._charsetMap[idx.toString()];

--- a/rtf.js
+++ b/rtf.js
@@ -161,7 +161,6 @@ if (typeof RTFJS === "undefined") {
 		
 		_charsetMap: {
 			"0":   1252, // ANSI_CHARSET
-			"2":   42,    // Symbol
 			"77":  10000, // Mac Roman
 			"78":  10001, // Mac Shift Jis
 			"79":  10003, // Mac Hangul
@@ -1964,7 +1963,7 @@ RTFJS.Document.prototype.parse = function(blob, renderer) {
 					var codepage = parser.codepage;
 					if (parser.state.chp.hasOwnProperty("fontfamily")) {
 						idx = parser.state.chp.fontfamily;
-						if (inst._fonts != undefined && inst._fonts[idx] != null)
+						if (inst._fonts != undefined && inst._fonts[idx] != null && inst._fonts[idx].charset != undefined)
 							codepage = inst._fonts[idx].charset;
 					}
 					


### PR DESCRIPTION
RTF seems to define charset for each fragment with related codepage; we should use it instead of main one.
We still need to define the charset mapping list.