### PR TITLE
fix iteration for object access

### DIFF
--- a/src/rtfjs/parser/destinations/ColortblDestinations.ts
+++ b/src/rtfjs/parser/destinations/ColortblDestinations.ts
@@ -113,11 +113,11 @@ export class ColortblDestination extends DestinationBase {
         if (this._autoIndex >= this._colors.length) {
             throw new RTFJSError("colortbl doesn't define auto color");
         }
-        for (const idx in this._colors) {
-            Helper.log("[colortbl] [" + idx + "] = "
-                + this._colors[idx].r + "," + this._colors[idx].g + "," + this._colors[idx].b
-                + " theme: " + this._colors[idx].theme);
-        }
+        this._colors.forEach((color, idx) => { 
+            Helper.log("[colortbl] [" + idx + "] = " 
+                + color.r + "," + color.g + "," + color.b 
+                + " theme: " + color.theme); 
+        });
         this.inst._colors = this._colors;
         this.inst._autoColor = this._autoIndex;
         delete this._colors;

--- a/src/rtfjs/parser/destinations/FonttblDestinations.ts
+++ b/src/rtfjs/parser/destinations/FonttblDestinations.ts
@@ -152,10 +152,10 @@ export class FonttblDestination extends DestinationBase {
 
     public apply(): void {
         Helper.log("[fonttbl] apply()");
-        for (const idx in this._fonts) {
-            Helper.log("[fonttbl][" + idx + "] index = " + this._fonts[idx].fontname
-                + " alternative: " + this._fonts[idx].altfontname);
-        }
+        this._fonts.forEach((font, idx) => { 
+            Helper.log("[fonttbl][" + idx + "] index = " + font.fontname 
+                + " alternative: " + font.altfontname); 
+        });
         this.inst._fonts = this._fonts;
         delete this._fonts;
     }

--- a/src/rtfjs/parser/destinations/StylesheetDestination.ts
+++ b/src/rtfjs/parser/destinations/StylesheetDestination.ts
@@ -109,9 +109,9 @@ export class StylesheetDestination extends DestinationBase {
 
     public apply(): void {
         Helper.log("[stylesheet] apply()");
-        for (const idx in this._stylesheets) {
-            Helper.log("[stylesheet] [" + idx + "] name: " + this._stylesheets[idx].name);
-        }
+        this._stylesheets.forEach((stylesheet, idx) => { 
+            Helper.log("[stylesheet] [" + idx + "] name: " + stylesheet.name); 
+        });
         this.inst._stylesheets = this._stylesheets;
         delete this._stylesheets;
     }


### PR DESCRIPTION
- The previous version of iteration was accessing array values **AND** some properties of an object (like `toJSON()`). And if `toJSON()` is `null` then the execution crashes.

- The new version of iteration is accessing **ONLY** array values.